### PR TITLE
Add "-L" option to produce CSV output that includes timestamps

### DIFF
--- a/README
+++ b/README
@@ -29,6 +29,10 @@ or get a line-by-line output like this:
 
 % ./sflowtool -p 6434 -l
 
+or get a line-by-line output including timestamps like this:
+
+% ./sflowtool -p 6434 -L
+
 In a typical application, this output would be parsed by an awk or perl script, perhaps to
 extract MAC->IP address-mappings or to extract a particular counter for trending. The
 usage might then look more like this:
@@ -198,6 +202,9 @@ for each flow or counter sample. It will look something like this:
     [root@server src]# ./sflowtool -l
     CNTR,10.0.0.254,17,6,100000000,0,2147483648,175283006,136405187,2578019,297011,0,3,0,0,0,0,0,0,0,1
     FLOW,10.0.0.254,0,0,00902773db08,001083265e00,0x0800,0,0,10.0.0.1,10.0.0.254,17,0x00,64,35690,161,0x00,143,125,80
+
+Running sflowtool using the "-L" option will produce very similar output, but
+a timestamp will be inserted as the third column in the CSV output.
 
 The counter samples are indicated with the "CNTR" entry in the first column.
 The second column is the agent address.  The remaining columns are the

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ or get a line-by-line output like this:
 
 % ./sflowtool -p 6434 -l
 
+or get a line-by-line output including timestamps like this:
+
+% ./sflowtool -p 6434 -L
+
 In a typical application, this output would be parsed by an awk or perl script, perhaps to
 extract MAC->IP address-mappings or to extract a particular counter for trending. The
 usage might then look more like this:
@@ -198,6 +202,9 @@ for each flow or counter sample. It will look something like this:
     [root@server src]# ./sflowtool -l
     CNTR,10.0.0.254,17,6,100000000,0,2147483648,175283006,136405187,2578019,297011,0,3,0,0,0,0,0,0,0,1
     FLOW,10.0.0.254,0,0,00902773db08,001083265e00,0x0800,0,0,10.0.0.1,10.0.0.254,17,0x00,64,35690,161,0x00,143,125,80
+
+Running sflowtool using the "-L" option will produce very similar output, but
+a timestamp will be inserted as the third column in the CSV output.
 
 The counter samples are indicated with the "CNTR" entry in the first column.
 The second column is the agent address.  The remaining columns are the

--- a/src/sflowtool.c
+++ b/src/sflowtool.c
@@ -820,7 +820,7 @@ static void writeFlowLine(SFSample *sample, int writeTimestamp)
   if(writeTimestamp == YES) {
     char nowstr[200];
     time_t now = sample->pcapTimestamp ?: sample->readTimestamp;
-    strftime(nowstr,200,"%Y-%m-%dT%H:%M:%S",localtime(&now));
+    strftime(nowstr,200,"%Y-%m-%d %H:%M:%S",localtime(&now));
     printf("%s,", nowstr);
   }
   /* layer 2 */
@@ -878,7 +878,7 @@ static void writeCountersLine(SFSample *sample, int writeTimestamp)
   if(writeTimestamp == YES) {
     char nowstr[200];
     time_t now = sample->pcapTimestamp ?: sample->readTimestamp;
-    strftime(nowstr,200,"%Y-%m-%dT%H:%M:%S",localtime(&now));
+    strftime(nowstr,200,"%Y-%m-%d %H:%M:%S",localtime(&now));
     printf("%s,", nowstr);
   }
   if(printf("%u,%u,%"PRIu64",%u,%u,%"PRIu64",%u,%u,%u,%u,%u,%u,%"PRIu64",%u,%u,%u,%u,%u,%u\n",

--- a/src/sflowtool.c
+++ b/src/sflowtool.c
@@ -820,7 +820,7 @@ static void writeFlowLine(SFSample *sample, int writeTimestamp)
   if(writeTimestamp == YES) {
     char nowstr[200];
     time_t now = sample->pcapTimestamp ?: sample->readTimestamp;
-    strftime(nowstr,200,"%d/%b/%Y:%H:%M:%S",localtime(&now));
+    strftime(nowstr,200,"%Y-%m-%d %H:%M:%S",localtime(&now));
     printf("%s,", nowstr);
   }
   /* layer 2 */
@@ -878,7 +878,7 @@ static void writeCountersLine(SFSample *sample, int writeTimestamp)
   if(writeTimestamp == YES) {
     char nowstr[200];
     time_t now = sample->pcapTimestamp ?: sample->readTimestamp;
-    strftime(nowstr,200,"%d/%b/%Y:%H:%M:%S",localtime(&now));
+    strftime(nowstr,200,"%Y-%m-%d %H:%M:%S",localtime(&now));
     printf("%s,", nowstr);
   }
   if(printf("%u,%u,%"PRIu64",%u,%u,%"PRIu64",%u,%u,%u,%u,%u,%u,%"PRIu64",%u,%u,%u,%u,%u,%u\n",

--- a/src/sflowtool.c
+++ b/src/sflowtool.c
@@ -820,7 +820,7 @@ static void writeFlowLine(SFSample *sample, int writeTimestamp)
   if(writeTimestamp == YES) {
     char nowstr[200];
     time_t now = sample->pcapTimestamp ?: sample->readTimestamp;
-    strftime(nowstr,200,"%Y-%m-%d %H:%M:%S",localtime(&now));
+    strftime(nowstr,200,"%Y-%m-%dT%H:%M:%S",localtime(&now));
     printf("%s,", nowstr);
   }
   /* layer 2 */
@@ -878,7 +878,7 @@ static void writeCountersLine(SFSample *sample, int writeTimestamp)
   if(writeTimestamp == YES) {
     char nowstr[200];
     time_t now = sample->pcapTimestamp ?: sample->readTimestamp;
-    strftime(nowstr,200,"%Y-%m-%d %H:%M:%S",localtime(&now));
+    strftime(nowstr,200,"%Y-%m-%dT%H:%M:%S",localtime(&now));
     printf("%s,", nowstr);
   }
   if(printf("%u,%u,%"PRIu64",%u,%u,%"PRIu64",%u,%u,%u,%u,%u,%u,%"PRIu64",%u,%u,%u,%u,%u,%u\n",

--- a/src/sflowtool.c
+++ b/src/sflowtool.c
@@ -5123,6 +5123,7 @@ static void instructions(char *command)
   fprintf(ERROUT,"\n");
   fprintf(ERROUT,"txt output:\n");
   fprintf(ERROUT, "   -l                 -  (output in line-by-line CSV format)\n");
+  fprintf(ERROUT, "   -L                 -  (output in line-by-line CSV format, with timestamps)\n");
   fprintf(ERROUT, "   -g                 -  (output in 'grep-friendly' format)\n");
   fprintf(ERROUT, "   -H                 -  (output HTTP common log file format)\n");
   fprintf(ERROUT,"\n");


### PR DESCRIPTION
I've done some relatively simple changes to add a "-L" option to have CSV line-by-line output that includes timestamps.

This would resolve issue #12 and is desirable for those that will be using sflowtool for SNIA Emerald/EPA Energy Star for Data Center Storage testing using the new test specifications for file access storage testing.

I have tested this with host sFlow as a source for data on both Linux CentOS 7.4 as well as TrueOS 17.12 (based on FreeBSD 12-CURRENT.) I have validated both CNTR and FLOW types include timestamps. I specifically left the lower-case "-l" flag intact to avoid compatibility issues.