### PR TITLE
Refer pcapTimestamp or readTimestamp when from Pcap(using -r option)

### DIFF
--- a/src/sflowtool.c
+++ b/src/sflowtool.c
@@ -1800,7 +1800,7 @@ static void writePcapPacket(SFSample *sample) {
   char buf[SA_MAX_PCAP_PKT];
   int bytes = 0;
   struct pcap_pkthdr hdr;
-  hdr.ts_sec = (uint32_t)time(NULL);
+  hdr.ts_sec = sample->pcapTimestamp ?: sample->readTimestamp;
   hdr.ts_usec = 0;
   hdr.len = sample->s.sampledPacketSize;
   hdr.caplen = sample->s.headerLen;


### PR DESCRIPTION
 I found the output timestamp was just current time in the case reading from pcap file. '-r' option is much useful for me, I often let it read from pcap file especially. 
 I suggest that the timestamp of sflow record refer timestamp of pcap record header when input is pcap file.