### PR TITLE
Read pcap packet

### DIFF
--- a/src/sflowtool.c
+++ b/src/sflowtool.c
@@ -5464,6 +5464,11 @@ static int readPcapPacket(FILE *file)
     hdr.len = MyByteSwap32(hdr.len);
   }
 
+  if(SA_MAX_PCAP_PKT < hdr.caplen || hdr.caplen<0 || hdr.len<0) {
+    fprintf(ERROUT, "incomplete datagram (pcap snaplen negative or too long than buffer)\n");
+    return 0;
+  }
+
   if(fread(buf, hdr.caplen, 1, file) != 1) {
     fprintf(ERROUT, "unable to read pcap packet from %s : %s\n", sfConfig.readPcapFileName, strerror(errno));
     exit(-34);

--- a/src/sflowtool.c
+++ b/src/sflowtool.c
@@ -5464,7 +5464,7 @@ static int readPcapPacket(FILE *file)
     hdr.len = MyByteSwap32(hdr.len);
   }
 
-  if(SA_MAX_PCAP_PKT < hdr.caplen || hdr.caplen<0 || hdr.len<0) {
+  if(SA_MAX_PCAP_PKT < hdr.caplen || hdr.caplen<0 ) {
     fprintf(ERROUT, "incomplete datagram (pcap snaplen negative or too long than buffer)\n");
     return 0;
   }


### PR DESCRIPTION
 I suggest that parameters would be checked before reading a record in pcap reading mode. It is possible that it will cause buffer overflow.
 Some broken pcap files will pass invalid pcap length to process. Almost of the case it happen on end of the file, so not important issue.