### PR TITLE
add -L ethernet_type for generic ethernet frames

### DIFF
--- a/src/sflowtool.c
+++ b/src/sflowtool.c
@@ -2971,7 +2971,7 @@ static void readFlowSample_header(SFSample *sample)
     sf_logf_U32_formatted(sample, NULL, "IPSize", "%d", sample->s.sampledPacketSize - sample->s.stripped - sample->s.offsetToIPV6);
     decodeIPV6(sample);
   }
-
+  sf_logf_U32(sample, "ethernet_type", sample->s.eth_type);
 }
 
 /*_________________---------------------------__________________


### PR DESCRIPTION
the `-L ethernet_type` parameter is only presented for certain types of raw ethernet frames.  This patches it back in for generic frames, including ipv4 / ipv6.

There may be more appropriate places in the code base to handle this.