### PR TITLE
Don't die if the sample is corrupt

### DIFF
--- a/src/sflowtool.c
+++ b/src/sflowtool.c
@@ -2958,7 +2958,7 @@ static void readFlowSample_header(SFSample *sample)
     break;
   default:
     fprintf(ERROUT, "undefined headerProtocol = %d\n", sample->s.headerProtocol);
-    exit(-12);
+    break;
   }
 
   if(sample->s.gotIPV4) {


### PR DESCRIPTION
Cumulus Linux on mlnx spectrum emits corrupt samples, which will normally cause sflowtool to crash and burn.  This patch causes sflowtool to ignore these samples and carry on.