### PR TITLE
add option to listen on loopback only

### DIFF
--- a/src/sflowtool.c
+++ b/src/sflowtool.c
@@ -259,6 +259,7 @@ typedef struct _SFConfig {
   int listen4;
   int listen6;
   int listenControlled;
+  int listenLoopback;
 
   /* general options */
   int keepGoing;
@@ -5203,7 +5204,7 @@ static void receiveSFlowDatagram(SFSample *sample)
    -----------------_____________________________------------------
 */
 
-static int openInputUDPSocket(uint16_t port)
+static int openInputUDPSocket(uint16_t port, int listenLoopback)
 {
   int soc;
   struct sockaddr_in myaddr_in;
@@ -5211,7 +5212,7 @@ static int openInputUDPSocket(uint16_t port)
   /* Create socket */
   memset((char *)&myaddr_in, 0, sizeof(struct sockaddr_in));
   myaddr_in.sin_family = AF_INET;
-  /* myaddr_in6.sin6_addr.s_addr = INADDR_ANY; */
+  myaddr_in.sin_addr.s_addr = htonl(listenLoopback ? INADDR_LOOPBACK : INADDR_ANY);
   myaddr_in.sin_port = htons(port);
 
   if ((soc = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == -1) {
@@ -5239,7 +5240,7 @@ static int openInputUDPSocket(uint16_t port)
    -----------------_____________________________------------------
 */
 
-static int openInputUDP6Socket(uint16_t port)
+static int openInputUDP6Socket(uint16_t port, int listenLoopback)
 {
   int soc;
   struct sockaddr_in6 myaddr_in6;
@@ -5247,7 +5248,7 @@ static int openInputUDP6Socket(uint16_t port)
   /* Create socket */
   memset((char *)&myaddr_in6, 0, sizeof(struct sockaddr_in6));
   myaddr_in6.sin6_family = AF_INET6;
-  /* myaddr_in6.sin6_addr = INADDR_ANY; */
+  myaddr_in6.sin6_addr = listenLoopback ? in6addr_loopback : in6addr_any;
   myaddr_in6.sin6_port = htons(port);
 
   if ((soc = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP)) == -1) {
@@ -5828,6 +5829,7 @@ static void instructions(char *command)
   fprintf(ERROUT, "   -v <vlans>         -  exclude vlans\n");
   fprintf(ERROUT, "   -4                 -  listen on IPv4 socket only\n");
   fprintf(ERROUT, "   -6                 -  listen on IPv6 socket only\n");
+  fprintf(ERROUT, "   -O                 -  listen on loopback only\n");
   fprintf(ERROUT, "   +4                 -  listen on both IPv4 and IPv6 sockets\n");
   fprintf(ERROUT, "\n");
   fprintf(ERROUT, "=============== Advanced Tools ===========================================\n");
@@ -5884,6 +5886,7 @@ static void process_command_line(int argc, char *argv[])
     case 'D':
     case '4':
     case '6':
+    case 'O':
     case 'k':
     case '?':
     case 'h':
@@ -5976,6 +5979,8 @@ static void process_command_line(int argc, char *argv[])
       sfConfig.listen4 = NO;
       sfConfig.listen6 = YES;
       break;
+    case 'O':
+      sfConfig.listenLoopback = YES;
     case 'k':
       sfConfig.keepGoing = YES;
       break;
@@ -6028,10 +6033,10 @@ int main(int argc, char *argv[])
        however,  we will probably need to allow the bind() to be on a particular v4 or v6
        address.  Otherwise it seems likely that we will get a clash(?) */
     if(sfConfig.listen6) {
-      soc6 = openInputUDP6Socket(sfConfig.sFlowInputPort);
+      soc6 = openInputUDP6Socket(sfConfig.sFlowInputPort, sfConfig.listenLoopback);
     }
     if(sfConfig.listen4 || (soc6 == -1 && !sfConfig.listenControlled)) {
-      soc4 = openInputUDPSocket(sfConfig.sFlowInputPort);
+      soc4 = openInputUDPSocket(sfConfig.sFlowInputPort, sfConfig.listenLoopback);
     }
     if(soc4 == -1 && soc6 == -1) {
       fprintf(ERROUT, "unable to open UDP read socket\n");


### PR DESCRIPTION
## scope

Use `-O` to listen on loopback only – with keeping AFI selection by `-4` / `-6`.

I guess it would be more valuable to add option to define listening address, but for my use-case listening on any vs loopback is enough and I see this patch as a good start.

## verification

I expect no behavior change if `sflowtool` is run w/o `-O`. Output of `netstat -anpl | fgrep sflow` is attached for verification.

### listening on any
#### `sflowtool`
```
udp6       0      0 :::6343                 :::*                                1629540/src/sflowto 
```

#### `sflowtool -4`
```
udp        0      0 0.0.0.0:6343            0.0.0.0:*                           1629694/src/sflowto 
```

#### `sflowtool -6`
```
udp6       0      0 :::6343                 :::*                                1629769/src/sflowto 
```
### listening on loopback only
#### `sflowtool -O`
```
udp6       0      0 ::1:6343                :::*                                1629842/src/sflowto 
```

#### `sflowtool -4 -O` (or `-4O`)
```
udp        0      0 127.0.0.1:6343          0.0.0.0:*                           1629864/src/sflowto 
```

#### `sflowtool -6 -O` (or `-6O`)
```
udp6       0      0 ::1:6343                :::*                                1629905/src/sflowto 
```
