### PR TITLE
add option to listen on specified address

### DIFF
--- a/src/sflowtool.c
+++ b/src/sflowtool.c
@@ -259,6 +259,7 @@ typedef struct _SFConfig {
   int listen4;
   int listen6;
   int listenControlled;
+  char *listenAddress;
 
   /* general options */
   int keepGoing;
@@ -5203,7 +5204,7 @@ static void receiveSFlowDatagram(SFSample *sample)
    -----------------_____________________________------------------
 */
 
-static int openInputUDPSocket(uint16_t port)
+static int openInputUDPSocket(char *address, uint16_t port)
 {
   int soc;
   struct sockaddr_in myaddr_in;
@@ -5211,7 +5212,14 @@ static int openInputUDPSocket(uint16_t port)
   /* Create socket */
   memset((char *)&myaddr_in, 0, sizeof(struct sockaddr_in));
   myaddr_in.sin_family = AF_INET;
-  /* myaddr_in6.sin6_addr.s_addr = INADDR_ANY; */
+  if (address) {
+    if (inet_pton(AF_INET, address, &myaddr_in.sin_addr) != 1) {
+      fprintf(ERROUT, "could not parse '%s' as an IPv4 address\n", address);
+      return -1;
+    }
+  } else {
+    myaddr_in.sin_addr.s_addr = htonl(INADDR_ANY);
+  }
   myaddr_in.sin_port = htons(port);
 
   if ((soc = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == -1) {
@@ -5239,7 +5247,7 @@ static int openInputUDPSocket(uint16_t port)
    -----------------_____________________________------------------
 */
 
-static int openInputUDP6Socket(uint16_t port)
+static int openInputUDP6Socket(char *address, uint16_t port)
 {
   int soc;
   struct sockaddr_in6 myaddr_in6;
@@ -5247,7 +5255,14 @@ static int openInputUDP6Socket(uint16_t port)
   /* Create socket */
   memset((char *)&myaddr_in6, 0, sizeof(struct sockaddr_in6));
   myaddr_in6.sin6_family = AF_INET6;
-  /* myaddr_in6.sin6_addr = INADDR_ANY; */
+  if (address) {
+    if (inet_pton(AF_INET6, address, &myaddr_in6.sin6_addr) != 1) {
+      fprintf(ERROUT, "could not parse '%s' as an IPv6 address\n", address);
+      return -1;
+    }
+  } else {
+    myaddr_in6.sin6_addr = in6addr_any;
+  }
   myaddr_in6.sin6_port = htons(port);
 
   if ((soc = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP)) == -1) {
@@ -5828,6 +5843,8 @@ static void instructions(char *command)
   fprintf(ERROUT, "   -v <vlans>         -  exclude vlans\n");
   fprintf(ERROUT, "   -4                 -  listen on IPv4 socket only\n");
   fprintf(ERROUT, "   -6                 -  listen on IPv6 socket only\n");
+  fprintf(ERROUT, "   -b <address>       -  listen on selected address only\n");
+  fprintf(ERROUT, "                         (must match address family selected by -4 / -6)\n");
   fprintf(ERROUT, "   +4                 -  listen on both IPv4 and IPv6 sockets\n");
   fprintf(ERROUT, "\n");
   fprintf(ERROUT, "=============== Advanced Tools ===========================================\n");
@@ -5896,6 +5913,7 @@ static void process_command_line(int argc, char *argv[])
     case 'd':
     case 'f':
     case 'N':
+    case 'b':
     case 'v': if(arg < argc) break;
     default: instructions(*argv); exit(1);
     }
@@ -5976,6 +5994,10 @@ static void process_command_line(int argc, char *argv[])
       sfConfig.listen4 = NO;
       sfConfig.listen6 = YES;
       break;
+    case 'b':
+      sfConfig.listenControlled = YES;
+      sfConfig.listenAddress = argv[arg++];
+      break;
     case 'k':
       sfConfig.keepGoing = YES;
       break;
@@ -6028,10 +6050,10 @@ int main(int argc, char *argv[])
        however,  we will probably need to allow the bind() to be on a particular v4 or v6
        address.  Otherwise it seems likely that we will get a clash(?) */
     if(sfConfig.listen6) {
-      soc6 = openInputUDP6Socket(sfConfig.sFlowInputPort);
+      soc6 = openInputUDP6Socket(sfConfig.listenAddress, sfConfig.sFlowInputPort);
     }
     if(sfConfig.listen4 || (soc6 == -1 && !sfConfig.listenControlled)) {
-      soc4 = openInputUDPSocket(sfConfig.sFlowInputPort);
+      soc4 = openInputUDPSocket(sfConfig.listenAddress, sfConfig.sFlowInputPort);
     }
     if(soc4 == -1 && soc6 == -1) {
       fprintf(ERROUT, "unable to open UDP read socket\n");


### PR DESCRIPTION
#44 reworked

## verification

I expect no behavior change if `sflowtool` is run w/o `-b`. Output of `netstat -npl | fgrep sflow` is attached for verification.

### listening on implicit any
#### `sflowtool`
```
udp6       0      0 :::6343                 :::*                                1682591/src/sflowto 
```

#### `sflowtool -4`
```
udp        0      0 0.0.0.0:6343            0.0.0.0:*                           1682657/src/sflowto 
```

#### `sflowtool -6`
```
udp6       0      0 :::6343                 :::*                                1682679/src/sflowto 
```

### listening on explicit any
#### `sflowtool -4 -b 0.0.0.0`
```
udp        0      0 0.0.0.0:6343            0.0.0.0:*                           1682727/src/sflowto 
```

#### `sflowtool -6 -b ::`
```
udp6       0      0 :::6343                 :::*                                1682783/src/sflowto
```

### listening on localhost
#### `sflowtool -4 -b 127.0.0.1`
```
udp        0      0 127.0.0.1:6343          0.0.0.0:*                           1682896/src/sflowto
```

#### `sflowtool -6 -b ::1`
```
udp6       0      0 ::1:6343                :::*                                1682933/src/sflowto
```

### listening on arbitrary IP
#### `sflowtool -4 -b 192.168.8.1`
```
udp        0      0 192.168.8.1:6343        0.0.0.0:*                           1683018/src/sflowto
```

### wrong AFI or malformed IP
```
$ src/sflowtool -4 -b 127.0.0.0.1
could not parse '127.0.0.0.1' as an IPv4 address
unable to open UDP read socket
$ src/sflowtool -6 -b 192.168.8.1
could not parse '192.168.8.1' as an IPv6 address
unable to open UDP read socket
$ src/sflowtool -6 -b bad
could not parse 'bad' as an IPv6 address
unable to open UDP read socket
```

