### PR TITLE
decode IP header from samples of MPLS-encapsulated packets

### DIFF
--- a/src/sflowtool.c
+++ b/src/sflowtool.c
@@ -1605,6 +1605,26 @@ static void decodeLinkLayer(SFSample *sample)
     sample->s.gotIPV6 = YES;
     sample->s.offsetToIPV6 = (ptr - start);
   }
+
+  if(type_len == 0x8847) {
+    /* MPLS unicast - 4 bytes */
+    ptr += 4;
+    /* look at first byte of possible IP header.... */
+    if((*ptr >> 4) == 4) {
+      /* IPV4 - check again that we have enough header bytes */
+      if((end - ptr) < sizeof(struct myiphdr)) return;
+      if((*ptr & 15) < 5) return; /* not IP (hdr len must be 5 quads or more) */
+      /* survived all the tests - store the offset to the start of the ip header */
+      sample->s.gotIPV4 = YES;
+      sample->s.offsetToIPV4 = (ptr - start);
+    }
+    else if((*ptr >> 4) == 6) {
+      /* IPV6 */
+      /* survived all the tests - store the offset to the start of the ip6 header */
+      sample->s.gotIPV6 = YES;
+      sample->s.offsetToIPV6 = (ptr - start);
+    }
+  }
 }
 
 /*_________________---------------------------__________________


### PR DESCRIPTION
This change only applies to flow samples with format: "Raw packet header" (1) and header protocol: "Ethernet" (1) with encapsulated 1-element label stack of MPLS unicast.